### PR TITLE
Reduce scroll timeout

### DIFF
--- a/client/screens/instance_annotator_screen.kv
+++ b/client/screens/instance_annotator_screen.kv
@@ -195,8 +195,6 @@
             text: "X"
             on_release: root.layer_view.delete_layer_item(root.layer_name)
 
-
-
 <ImageCanvas>:
     image_id: self.image_id
     scatter: scatter
@@ -215,6 +213,7 @@
         pos: (0,0)
         ScrollView:
             scroll_type: ['bars', 'content']
+            scroll_timeout: 5
             bar_width: '10dp'
             id: scroll_view
             width: root.width / root.scatter.scale


### PR DESCRIPTION
Resolves #27 

This behavior arose from the way in which ScrollView monitors touch events for drag events. In this PR i reduce the window in which it monitors drag events to 5 milliseconds, this effectively removes the ability to click+drag to pan the image.

Click+Drag to pan could be enabled using an extension of ScrollView in the future.