### PR TITLE
Add robust keyboard shortcuts

### DIFF
--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -1,4 +1,3 @@
-from collections import deque
 import cv2
 import kivy.utils
 from kivy.app import App

--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -661,6 +661,7 @@ class DrawTool(MouseDrawnTool):
     def __init__(self, **kwargs):
         self.layer_view = None
 
+        self.keyboard_shortcuts = {}
         self.keycode_buffer = {}
         self._keyboard = Window.request_keyboard(
             self.unbind_keyboard, self, 'text')
@@ -668,6 +669,8 @@ class DrawTool(MouseDrawnTool):
 
         self.mask_stack = []
         self.delete_stack = []
+
+        self.bind_shortcuts()
         super().__init__(**kwargs)
 
     def bind_layer_view(self, layer_view):
@@ -676,7 +679,11 @@ class DrawTool(MouseDrawnTool):
     def bind_class_picker(self, class_picker):
         class_picker.fbind('eraser_enabled', self.setter('erase'))
 
-    def bind_keyboard(self,):
+    def bind_shortcuts(self):
+        self.keyboard_shortcuts[("lctrl", "z")] = self.undo
+        self.keyboard_shortcuts[("lctrl", "y")] = self.redo
+
+    def bind_keyboard(self):
         self._keyboard.bind(on_key_down=self.on_key_down)
         self._keyboard.bind(on_key_up=self.on_key_up)
 
@@ -692,11 +699,11 @@ class DrawTool(MouseDrawnTool):
 
     def on_key_up(self, keyboard, keycode):
         print("UP: %s" % (str(keycode[1])))
-        if 'lctrl' in self.keycode_buffer:
-            if keycode[1] == 'z':
-                self.undo()
-            elif keycode[1] == 'y':
-                self.redo()
+
+        for shortcut in self.keyboard_shortcuts.keys():
+            if keycode[1] in shortcut and set(shortcut).issubset(self.keycode_buffer):
+                self.keyboard_shortcuts[shortcut]()
+
         self.keycode_buffer.pop(keycode[1])
 
     def undo(self):


### PR DESCRIPTION
Resolves #28 

Due to the nature of the kivy framework each key release is scheduled for a "on_key_up" event individually. This PR introduces the binding of shortcuts so that regardless of which key in the shortcut is released first, the intended action is still executed.

While this behavior is somewhat atypical for desktop applications (releasing ctrl before z still executes ctrl+z) it is more user friendly than the current implementation.

A future feature could collate key events into frame by frame collections to allow for a more traditional UX.