### PR TITLE
Enforce step size on Numeric Input

### DIFF
--- a/client/screens/common.kv
+++ b/client/screens/common.kv
@@ -70,13 +70,11 @@
         Button:
             text: '+'
             disabled: root.value >= root.max
-            on_release:
-                root.value = round(min(root.value + root.step, root.max), root.decimal_places)
+            on_release: root.increment(1)
         Button:
             text: '-'
             disabled: root.value <= root.min
-            on_release:
-                root.value = round(max(root.value - root.step, root.min), root.decimal_places)
+            on_release: root.increment(-1)
 
 <PaintWindow>
     mask_layer: mask_layer

--- a/client/screens/common.py
+++ b/client/screens/common.py
@@ -1,5 +1,5 @@
 import os
-
+import math
 import numpy as np
 from kivy.graphics import Rectangle, Fbo
 from kivy.lang import Builder
@@ -63,6 +63,7 @@ class MouseDrawnTool(FloatLayout):
 
 
 class NumericInput(StackLayout):
+    decimal_places = NumericProperty(0)
     value = NumericProperty(0)
     min = NumericProperty(-float('inf'))
     max = NumericProperty(float('inf'))
@@ -73,14 +74,29 @@ class NumericInput(StackLayout):
         try:
             user_input = float(self.text_input.text)
         except ValueError:
-            self.text_input.text = str(self.value)
+            pass
         else:
-            self.value = type(
-                self.value)(
+            self.value = type(self.value)(
                 np.clip(
                     user_input,
                     self.min,
                     self.max))
+        finally:
+            self.text_input.text = str(self.value)
+
+    def increment(self, n):
+        # To accommodate for floating point division
+        x = round(self.value / self.step, 10)
+        # Round down to the nearest 'step size'
+        x = math.floor(x) * self.step
+        # Add n 'step size'
+        x = x + (n * self.step)
+        # Round to desired display decimal places
+        x = round(x, self.decimal_places)
+        # Clip to bounds
+        x = np.clip(x, self.min, self.max)
+        # Maintain type of value (int or float)
+        self.value = type(self.value)(x)
 
 
 class TransparentBlackEffect(EffectBase):

--- a/client/screens/instance_annotator_screen.kv
+++ b/client/screens/instance_annotator_screen.kv
@@ -61,6 +61,8 @@
         Label:
             text: "pen size"
         NumericInput:
+            min: 1
+            max: 100
             value: 10
             step: 5
             on_value: root.set_pencil_size(self.value)

--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -864,7 +864,6 @@ class DrawTool(MouseDrawnTool):
         g.add(Rectangle(size=(width, height),
                         pos=tuple(self.layer.bbox_bounds[:2]),
                         texture=utils.mat2texture(mat)))
-
         self.add_action(g)
 
 


### PR DESCRIPTION
Resolves #29 

This PR enforces step size increments on Numeric Inputs. Manual input outside of this step range is allowed but validation is performed to ensure inputs are of the same type and precision.