### PR TITLE
Fix keyboard close on TextInput

### DIFF
--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -662,8 +662,7 @@ class DrawTool(MouseDrawnTool):
 
         self.keyboard_shortcuts = {}
         self.keycode_buffer = {}
-        self._keyboard = Window.request_keyboard(
-            self.unbind_keyboard, self, 'text')
+        self._keyboard = Window.request_keyboard(lambda: None, self)
         self._consecutive_selects = 0
 
         self.mask_stack = []


### PR DESCRIPTION
Resolves #30 

This issue arose from selection of TextInput fields triggering the closure of the keyboard object. It is unclear why this occurs but this PR delays the unbinding of the keyboard to on_leave.