### PR TITLE
Make undo/redo stable across multiple layers

### DIFF
--- a/client/data/instance_annotator_screen.kv
+++ b/client/data/instance_annotator_screen.kv
@@ -227,19 +227,22 @@
             id: scroll_view
             width: root.width / root.scatter.scale
             height: root.height / root.scatter.scale
-            Image:
-                id: image
-                keep_ratio: True
-                pos: root.pos
+            on_size: print("ScrollView Size: %s" % str(self.size))
+            on_pos: print("ScrollView Pos: %s" % str(self.pos))
+            RelativeLayout:
+                pos: (0,0)
+                size: root.image.size
                 size_hint:(None, None)
-                FloatLayout:
-                    size: self.parent.size
-                    DrawTool:
-                        id: draw_tool
-                        size: self.parent.size
-                    LayerStack:
-                        id: layer_stack
-                        size: self.parent.size
+                Image:
+                    id: image
+                    keep_ratio: True
+                    pos: (0,0)
+                DrawTool:
+                    id: draw_tool
+                    pos: (0,0)
+                LayerStack:
+                    id: layer_stack
+                    pos: (0,0)
 
 
 <LayerStack>:

--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -494,6 +494,8 @@ class DrawTool(MouseDrawnTool):
         if not self.mask_stack:
             return
         action = self.mask_stack.pop()
+        if action.layer.parent is None:
+            self.undo()
         self.delete_stack.append(action)
         action.layer.remove_instruction(action.group)
         self.fit_bbox(layer=action.layer)
@@ -508,6 +510,8 @@ class DrawTool(MouseDrawnTool):
         if not self.delete_stack:
             return
         action = self.delete_stack.pop()
+        if action.layer.parent is None:
+            self.redo()
         self.mask_stack.append(action)
         action.layer.add_instruction(action.group)
         self.fit_bbox(layer=action.layer)

--- a/client/screens/instance_annotator_screen.py
+++ b/client/screens/instance_annotator_screen.py
@@ -125,13 +125,6 @@ class InstanceAnnotatorScreen(Screen):
     def on_enter(self, *args):
         self.fetch_image_metas()
         self.fetch_class_labels()
-        Window.bind(on_resize=self.auto_resize)
-
-    def auto_resize(self, *args):
-        image_canvas = self.get_current_image_canvas()
-        if image_canvas is None:
-            return
-        image_canvas.resize()
 
     @background
     def load_next(self):
@@ -499,6 +492,7 @@ class DrawTool(MouseDrawnTool):
         self.delete_stack.append(mask)
         self.layer.remove_instruction(mask)
         self.fit_bbox()
+        self.app.root.current_screen.controller.update_annotation()
 
     def redo(self):
         if not self.delete_stack:
@@ -840,7 +834,6 @@ class ImageCanvasTabPanel(TabbedPanel):
             self.current_tab.image_canvas.draw_tool.unbind_keyboard()
 
         header.image_canvas.draw_tool.bind_keyboard()
-        header.image_canvas.resize()
 
         screen = self.app.root.current_screen
         screen.controller.update_tool_state(
@@ -877,12 +870,6 @@ class ImageCanvas(BoxLayout):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.app = App.get_running_app()
-
-    @mainthread
-    def resize(self):
-        model = self.app.root.current_screen.model
-        image = model.images.get(model.tool.get_current_image_id())
-        self.load_image(image)
 
     def prepare_to_save(self):
         # Note: This method must be run on the main thread


### PR DESCRIPTION
Resolves #60 

In investigating #60 it was found that the undo/redo operations assumed actions were associated with the currently selected layer, which is not always the case.

An association was made between an Action and its layer to help resolve this issue.

Incidentally some scaling issues with ImageCanvas were also fixed.