### PR TITLE
[feature] Allow developers to run MySQL without installing it locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,17 @@ Note: For the following Installation steps please ensure pip is run with adminis
             ```
         1. Create a connection to the database and run the `database/create_database.sql` script
         1. (Optional) run the 'database/create_test_data.sql' script to populate tables with test data
-    
-             
+    3. Alternatively, Docker can be used to run a MySQL database for development. 
+        1. Download and install Docker and Docker Compose
+        2. Start the container with
+        ```
+       >> docker-compose up
+       ```
+       3. Stop the container with
+       ```
+       >> docker-compose down
+       ```
+       4. To stop the container and delete the volume (deleting all data in the DB)
+       ```
+       >> docker-compose down -v
+       ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.3'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'fadb'
+      MYSQL_ROOT_PASSWORD: 'root'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'
+    volumes:
+      - my-db:/var/lib/mysql
+# Names our volume
+volumes:
+  my-db:


### PR DESCRIPTION
EDIT:
To simplify the installation process, we can utilize docker to install our MySQL instance. This will improve the consistency of the installation across platforms and reduce the work required.
